### PR TITLE
start timer only once

### DIFF
--- a/src/timer-signal-field-component.ts
+++ b/src/timer-signal-field-component.ts
@@ -13,16 +13,21 @@ import {TimerSignalComponent} from './timer-signal-component';
 })
 export class TimerSignalFieldComponent {
   @ContentChild(TimerSignalComponent) timerSignal: TimerSignalComponent;
+  isOn: boolean;
 
   ngAfterContentInit() {
     this.turnOn();
   }
 
   turnOn() {
-    this.timerSignal.start();
+    if(!this.isOn) {
+      this.timerSignal.start();
+      this.isOn = true;
+    }
   }
 
   turnOff() {
     this.timerSignal.stop();
+    this.isOn = false;
   }
 }


### PR DESCRIPTION
As shown during the workshop, the "turnOn" method should start the timer only if it's not already running.